### PR TITLE
add trees and connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
 COPY . .
-CMD ["python", "manage.py", "run"]
+CMD ["python", "-u", "manage.py", "run"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,9 +7,9 @@ def create_app(config_name):
     app.config.from_object(config_by_name[config_name])
 
     # Import all API blueprints from the __init__.py file
-    from app.api import node_blueprint, tree_blueprint
+    import app.api as api
 
-    app.register_blueprint(node_blueprint)
-    app.register_blueprint(tree_blueprint)
+    app.register_blueprint(api.node_blueprint)
+    app.register_blueprint(api.tree_blueprint)
     
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,8 +7,9 @@ def create_app(config_name):
     app.config.from_object(config_by_name[config_name])
 
     # Import all API blueprints from the __init__.py file
-    from app.api import node_blueprint
+    from app.api import node_blueprint, tree_blueprint
 
     app.register_blueprint(node_blueprint)
+    app.register_blueprint(tree_blueprint)
     
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,9 +7,9 @@ def create_app(config_name):
     app.config.from_object(config_by_name[config_name])
 
     # Import all API blueprints from the __init__.py file
-    from app.api import node_blueprint, tree_blueprint
+    import app.api
 
-    app.register_blueprint(node_blueprint)
-    app.register_blueprint(tree_blueprint)
+    app.register_blueprint(app.api.node_blueprint)
+    app.register_blueprint(app.api.tree_blueprint)
     
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,9 +7,9 @@ def create_app(config_name):
     app.config.from_object(config_by_name[config_name])
 
     # Import all API blueprints from the __init__.py file
-    import app.api
+    from app.api import node_blueprint, tree_blueprint
 
-    app.register_blueprint(app.api.node_blueprint)
-    app.register_blueprint(app.api.tree_blueprint)
+    app.register_blueprint(node_blueprint)
+    app.register_blueprint(tree_blueprint)
     
     return app

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,4 +1,5 @@
 from .nodeRouter import node_blueprint
+from .treeRouter import tree_blueprint
 
 # Export API blueprints here
-__all__ = ["node_blueprint"]
+__all__ = ["node_blueprint", "tree_blueprint"]

--- a/app/api/nodeRouter.py
+++ b/app/api/nodeRouter.py
@@ -26,7 +26,7 @@ def getNode(node_id):
 
 @node_blueprint.route("/<node_id>/children", methods=["GET"])
 def getNodeAndChildren(node_id):
-    nodes = nodeService.getNodeAndChildren(node_id)
+    nodes = nodeService.getNodeAndChildren(node_id, levels=1)
     if not nodes:
         return {"error" : "Unable to fetch nodes from database"}
     return jsonify(nodes)

--- a/app/api/nodeRouter.py
+++ b/app/api/nodeRouter.py
@@ -13,12 +13,22 @@ def getAllNodes():
 def postNode():
     node = request.get_json()
     if not node:
-        return "Error: No request body provided"
+        return {"error" : "No request body provided"}
     new_node = nodeService.postNode(node)
     return jsonify(new_node)
 
 @node_blueprint.route("/<node_id>", methods=["GET"])
 def getNode(node_id):
     node = nodeService.getNodeById(node_id)
+    if not node:
+        return {"error" : "Unable to fetch node from database"}
     return jsonify(node)
+
+@node_blueprint.route("/<node_id>/children", methods=["GET"])
+def getNodeAndChildren(node_id):
+    nodes = nodeService.getNodeAndChildren(node_id)
+    if not nodes:
+        return {"error" : "Unable to fetch nodes from database"}
+    return jsonify(nodes)
+
         

--- a/app/api/treeRouter.py
+++ b/app/api/treeRouter.py
@@ -8,6 +8,6 @@ tree_blueprint = Blueprint('tree_blueprint', __name__, url_prefix="/trees")
 def getTree(tree_id):
     nodes = treeService.getTree(tree_id)
     if not nodes:
-        return "Error: Unable to fetch nodes from database"
+        return {"error" : "Unable to fetch tree from database"}
     return jsonify(nodes)
         

--- a/app/api/treeRouter.py
+++ b/app/api/treeRouter.py
@@ -1,0 +1,13 @@
+from flask import request, json, jsonify, Blueprint
+
+from ..services import treeService
+
+tree_blueprint = Blueprint('tree_blueprint', __name__, url_prefix="/trees")
+
+@tree_blueprint.route("/<tree_id>", methods=["GET"])
+def getTree(tree_id):
+    nodes = treeService.getTree(tree_id)
+    if not nodes:
+        return "Error: Unable to fetch nodes from database"
+    return jsonify(nodes)
+        

--- a/app/database/models/__init__.py
+++ b/app/database/models/__init__.py
@@ -1,5 +1,5 @@
 from .nodeModel import BitByteNode
 from .treeModel import BitByteTree
-from .connectionModel import Connection
+from .connectionModel import ParentChildConnection
 
-__all__ = ["BitByteNode", "BitByteTree", "Connection"]
+__all__ = ["BitByteNode", "BitByteTree", "ParentChildConnection"]

--- a/app/database/models/__init__.py
+++ b/app/database/models/__init__.py
@@ -1,4 +1,5 @@
 from .nodeModel import BitByteNode
-from .connectionsModel import Connections
+from .treeModel import BitByteTree
+from .connectionModel import Connection
 
-__all__ = ["BitByteNode", "Connections"]
+__all__ = ["BitByteNode", "BitByteTree", "Connection"]

--- a/app/database/models/connectionModel.py
+++ b/app/database/models/connectionModel.py
@@ -1,6 +1,6 @@
 from .. import db
 
-class Connection(db.Model):
+class ParentChildConnection(db.Model):
     node_id = db.Column(db.Integer, db.ForeignKey("bit_byte_node.id"), primary_key=True)
     parent_node_id = db.Column(db.Integer, db.ForeignKey("bit_byte_node.id"))
 

--- a/app/database/models/connectionModel.py
+++ b/app/database/models/connectionModel.py
@@ -1,0 +1,9 @@
+from .. import db
+
+class Connection(db.Model):
+    node_id = db.Column(db.Integer, db.ForeignKey("bit_byte_node.id"), primary_key=True)
+    parent_node_id = db.Column(db.Integer, db.ForeignKey("bit_byte_node.id"))
+
+    def __init__(self, node_id, parent_node_id):
+        self.node_id = node_id
+        self.parent_node_id = parent_node_id

--- a/app/database/models/connectionsModel.py
+++ b/app/database/models/connectionsModel.py
@@ -1,9 +1,0 @@
-from .. import db
-
-class Connections(db.Model):
-    node_id = db.Column(db.Integer, db.ForeignKey("bit_byte_node.id"), primary_key=True)
-    parent_node_id = db.Column(db.Integer, db.ForeignKey("bit_byte_node.id"))
-
-    def __init__(self, node_id, parent_node_id):
-        self.node_id = node_id
-        self.parent_node_id = parent_node_id

--- a/app/database/models/nodeModel.py
+++ b/app/database/models/nodeModel.py
@@ -30,6 +30,7 @@ class BitByteNode(db.Model):
             "major": self.major,
             "college": self.college,
             "class_year": self.class_year,
+            "tree_name": self.tree_name,
             "quarter_joined": self.quarter_joined,
             "linkedin": self.linkedin,
             "facebook": self.facebook,

--- a/app/database/models/nodeModel.py
+++ b/app/database/models/nodeModel.py
@@ -1,8 +1,6 @@
-from flask_sqlalchemy import SQLAlchemy
 from .. import db
 
 class BitByteNode(db.Model):
-
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(128))
     major = db.Column(db.String(128))
@@ -32,7 +30,6 @@ class BitByteNode(db.Model):
             "major": self.major,
             "college": self.college,
             "class_year": self.class_year,
-            "tree_name": self.tree_name,
             "quarter_joined": self.quarter_joined,
             "linkedin": self.linkedin,
             "facebook": self.facebook,

--- a/app/database/models/treeModel.py
+++ b/app/database/models/treeModel.py
@@ -5,7 +5,7 @@ class BitByteTree(db.Model):
     
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(128))
-    root_id = db.Column(db.Integer, db.ForeignKey("bit_byte_tree.id"))
+    root_id = db.Column(db.Integer, db.ForeignKey("bit_byte_node.id"))
     # add points, badges, tree description, etc. if confirmed feature
 
     def __init__(self, name, root_id):

--- a/app/database/models/treeModel.py
+++ b/app/database/models/treeModel.py
@@ -1,0 +1,20 @@
+from .. import db
+
+# Supports easily pulling up entire trees and storing common information
+class BitByteTree(db.Model):
+    
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128))
+    root_id = db.Column(db.Integer, db.ForeignKey("bit_byte_tree.id"))
+    # add points, badges, tree description, etc. if confirmed feature
+
+    def __init__(self, name, root_id):
+        self.name = name
+        self.root_id = root_id
+    
+    def serialize(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "root_id": self.root_id
+        }

--- a/app/services/nodeService.py
+++ b/app/services/nodeService.py
@@ -1,4 +1,6 @@
 from ..database.models import BitByteNode
+from ..database.models import BitByteTree
+from ..database.models import Connection
 from ..database import db
 
 def getAllNodes():
@@ -9,8 +11,24 @@ def getNodeById(node_id):
     node = db.session.query(BitByteNode).filter_by(id=node_id).first()
     return node.serialize()
 
-def postNode(node):
+def postNode(node):  
+    parent_id = node.get("parent_id", None)
+    tree_id = db.session.query(BitByteTree.id).filter_by(name=node["tree_name"]).first()
+    
     new_node = BitByteNode(node)
     db.session.add(new_node)
-    db.session.commit()
+    db.session.flush()              # to access new_node.id
+
+    # create new Tree if doesnt exist, otherwise add to that tree
+    if not tree_id:
+        new_tree = BitByteTree(node["tree_name"], new_node.id)
+        db.session.add(new_tree)
+    
+    # create new Connection if Bit/Byte has parent
+    if parent_id:
+        new_connection = Connection(new_node.id, parent_id)
+        db.session.add(new_connection)
+
+    db.session.commit()    
+   
     return new_node.serialize()

--- a/app/services/treeService.py
+++ b/app/services/treeService.py
@@ -1,6 +1,5 @@
 from ..database.models import BitByteTree
 from ..database.models import BitByteNode
-from ..database.models import Connection
 from ..database import db
 
 from ..services import nodeService

--- a/app/services/treeService.py
+++ b/app/services/treeService.py
@@ -5,37 +5,14 @@ from ..database import db
 
 from ..services import nodeService
 
-from sqlalchemy.orm import aliased
-
 def getTree(tree_id):
-    root_id = db.session.query(BitByteTree.root_id).filter_by(id=tree_id).first()
-    
-    if not root_id:
+    tree = db.session.query(BitByteTree).filter_by(id=tree_id).first()
+    if not tree:
         return None
+
+    nodes = nodeService.getNodeAndChildren(tree.root_id)
     
-    root_node = nodeService.getNodeById(root_id)
-    root_node["parent_node_id"] = None
+    tree = tree.serialize()
+    tree["nodes"] = nodes
 
-    non_recursive_clause = db.session.query(Connection, BitByteNode)\
-        .join(BitByteNode, Connection.node_id == BitByteNode.id)\
-        .filter(Connection.parent_node_id == root_id).cte(name='parent_for', recursive=True)
-
-    with_recursive = non_recursive_clause.union_all(
-        db.session.query(Connection, BitByteNode)\
-            .join(BitByteNode, Connection.node_id == BitByteNode.id)\
-            .filter(Connection.parent_node_id == non_recursive_clause.c.node_id)
-    )
-
-    children_nodes = db.session.query(with_recursive).all()
-    
-    # children_nodes is list w/ elements of type NamedTuple, 
-    # so use built-in func _asdict()
-    nodes = ([(node._asdict()) for node in children_nodes])
-
-    # remove extra node_id needed in recursive calls for children nodes
-    for node in nodes:
-        del node["node_id"]
-
-    nodes.insert(0, root_node)
-    
-    return nodes
+    return tree

--- a/app/services/treeService.py
+++ b/app/services/treeService.py
@@ -1,0 +1,41 @@
+from ..database.models import BitByteTree
+from ..database.models import BitByteNode
+from ..database.models import Connection
+from ..database import db
+
+from ..services import nodeService
+
+from sqlalchemy.orm import aliased
+
+def getTree(tree_id):
+    root_id = db.session.query(BitByteTree.root_id).filter_by(id=tree_id).first()
+    
+    if not root_id:
+        return None
+    
+    root_node = nodeService.getNodeById(root_id)
+    root_node["parent_node_id"] = None
+
+    non_recursive_clause = db.session.query(Connection, BitByteNode)\
+        .join(BitByteNode, Connection.node_id == BitByteNode.id)\
+        .filter(Connection.parent_node_id == root_id).cte(name='parent_for', recursive=True)
+
+    with_recursive = non_recursive_clause.union_all(
+        db.session.query(Connection, BitByteNode)\
+            .join(BitByteNode, Connection.node_id == BitByteNode.id)\
+            .filter(Connection.parent_node_id == non_recursive_clause.c.node_id)
+    )
+
+    children_nodes = db.session.query(with_recursive).all()
+    
+    # children_nodes is list w/ elements of type NamedTuple, 
+    # so use built-in func _asdict()
+    nodes = ([(node._asdict()) for node in children_nodes])
+
+    # remove extra node_id needed in recursive calls for children nodes
+    for node in nodes:
+        del node["node_id"]
+
+    nodes.insert(0, root_node)
+    
+    return nodes


### PR DESCRIPTION
add Tree model to get entire trees and to attribute points, badges, etc. to a collective group and not just individual nodes

add getNodeAndChildren function to recursively get every descendant of current node and return to caller. follows this query logic:

```
WITH RECURSIVE children AS (
		SELECT node_id, parent_node_id, bit_byte_node.*
		FROM
			connection
		JOIN bit_byte_node on node_id = bit_byte_node.id
		WHERE
			parent_node_id = 1
	UNION
		SELECT
			c.node_id, c.parent_node_id, bit_byte_node.*
		FROM
			connection c
		JOIN children ON c.parent_node_id = children.node_id
		JOIN bit_byte_node ON c.node_id = bit_byte_node.id
) SELECT
	*
FROM
	children;
```

add GET /nodes/:id/children to get the current node and its children (for getting a sub-tree as opposed to an entire tree)